### PR TITLE
Fix Asana social auth redirect URL

### DIFF
--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -23,6 +23,7 @@ from django.utils.crypto import constant_time_compare, get_random_string
 from requests_oauthlib import OAuth1
 
 from sentry.utils import json
+from sentry.utils.http import absolute_uri
 from social_auth.exceptions import (
     AuthCanceled,
     AuthFailed,
@@ -355,10 +356,12 @@ class BaseAuth:
         instances.delete()
 
     def build_absolute_uri(self, path=None):
-        """Build absolute URI for given path. Replace http:// schema with
-        https:// if SOCIAL_AUTH_REDIRECT_IS_HTTPS is defined.
+        """Build absolute URI for given path.
+        We use absolute_uri instead of request.build_absolute_uri
+        to cover the case of a self-hosted user performing the
+        authentication behind a proxy.
         """
-        uri = self.request.build_absolute_uri(path)
+        uri = absolute_uri(path)
         if setting("SOCIAL_AUTH_REDIRECT_IS_HTTPS"):
             uri = uri.replace("http://", "https://")
         return uri

--- a/tests/social_auth/test_social_auth.py
+++ b/tests/social_auth/test_social_auth.py
@@ -1,0 +1,22 @@
+from urllib.parse import parse_qs
+
+from django.urls import reverse
+
+from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
+
+PROXY_URL_PREFIX = "https://sentry.example.com"
+
+
+@control_silo_test
+class AsanaSocialAuthTest(TestCase):
+    def test_redirect_uri_with_proxy(self):
+        with self.options({"system.url-prefix": PROXY_URL_PREFIX}):
+            response = self.client.post(
+                reverse("socialauth_associate", kwargs={"backend": "asana"})
+            )
+
+        assert response.status_code == 302
+
+        redirect_uri = parse_qs(response.url)["redirect_uri"][0]
+        assert redirect_uri.startswith(PROXY_URL_PREFIX)


### PR DESCRIPTION
This PR is a tentative to start solving [Issue #44424](https://github.com/getsentry/sentry/issues/44424).

The current use of `request.build_absolute_uri` is breaking social authentication for self-hosted users who have a proxy in front.`absolute_uri` builds with `url-prefix` while `request.build_absolute_uri` builds the URL based on the host of the request, which might not be the domain a user accesses their self-hosted instance from if they have a proxy.

We fix this by using `absolute_uri` instead of `request.build_absolute_uri` in `src/social_auth/backends/__init__.py` and by adding a corresponding test.

### Open questions

I'm not sure if creating a new `tests/social_auth` folder is justified or not. I did it because I couldn't find any other good place to put my test, but I might have missed something there.
